### PR TITLE
Fixed missing 'tagPrompt' parameter

### DIFF
--- a/src/exif-ai.ts
+++ b/src/exif-ai.ts
@@ -71,6 +71,7 @@ async function handleExecution(path: string) {
       model: options.model,
       descriptionTags: options.descriptionTags,
       tagTags: options.tagTags,
+      tagPrompt: options.tagPrompt,
       descriptionPrompt: options.descriptionPrompt,
       verbose: options.verbose,
       dry: options.dryRun,


### PR DESCRIPTION
tagPrompt parameter wasn't being passed through - adding this makes the '--tag-prompt' option actually work.